### PR TITLE
Fix SCRAM auth: return after do_sasl consumes AuthenticationOk

### DIFF
--- a/src/pg/replication/conn.rs
+++ b/src/pg/replication/conn.rs
@@ -239,6 +239,7 @@ impl ReplicationConn {
                 }
                 Message::AuthenticationSasl(body) => {
                     self.do_sasl(cfg, body).await?;
+                    return Ok(());
                 }
                 Message::AuthenticationMd5Password(_) => {
                     bail!("MD5 password auth not supported (use SCRAM-SHA-256 or trust)");


### PR DESCRIPTION
do_sasl reads frames in its own loop and returns once it sees AuthenticationOk, but do_auth then continued looping and read the following BackendKeyData frame, hitting the catch-all and failing with "unexpected auth message". Sources configured with scram-sha-256 could not authenticate.

Return from do_auth immediately after do_sasl succeeds; the post-auth ParameterStatus/BackendKeyData/ReadyForQuery sequence is handled by await_ready_for_query as usual.