### PR TITLE
roaring bitmaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1559,6 +1565,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "roaring"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2270,6 +2286,7 @@ dependencies = [
  "postgres-protocol",
  "quick-xml",
  "reqwest",
+ "roaring",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ percent-encoding = "2"
 base64 = "0.22"
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "stream", "json", "form", "query", "charset", "http2"] }
 crc32c = "0.6"
+roaring = "0.11"
 aws-lc-rs = "1"
 quick-xml = "0.40"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -156,10 +156,20 @@ capped at 64 steps + visited-set against cyclic sentinels; only the
 leaf's tablespace `Spec` is applied (it's a property of pgdata, not
 LSN).
 
-In-memory delta map is `BTreeMap<RelFileNode, BTreeSet<u32>>` rather
-than wal-g's RoaringBitmap: stdlib, on-disk format is a flat tuple list
-either way, typical deltas touch < 1 % of pages. Swappable if profiles
-disagree.
+In-memory delta map is `BTreeMap<RelFileNode, RoaringBitmap>`, matching
+wal-g's `map[RelFileNode]*roaring.Bitmap`. A `BTreeSet<u32>` costs a flat
+~13 B/block regardless of density, so a large-rewrite delta (VACUUM FULL,
+CREATE INDEX, bulk load: 100 GiB rel ≈ 13 M blocks) balloons to ~160 MB
+resident; roaring run/bitmap-compresses dense rewrites to ~1.6 MB and
+keeps sparse OLTP deltas comparable. The on-disk format is a flat tuple
+list either way, so it costs nothing in interop.
+
+The sidecar (`<group>_delta`) is never materialized as a struct: the
+running working file accumulates location tuples append-only across the
+group's 16 segments, then completion appends the boundary-record tuples,
+terminator, and parser seed and streams the file to the bucket. The map
+build folds each sidecar's tuples back in one at a time. So neither the
+sidecar write nor the map read holds a whole group's locations in memory.
 
 Walparser operates on byte slices rather than wal-g's reader-of-reader
 chains; one segment is 16 MiB and already in memory. wal summaries
@@ -227,7 +237,10 @@ server-requested-reply keepalives.
 
 Recurring theme: prefer hand-rolling small fixed formats over pulling
 crates. No `regex` (summary filenames + tablespace prefixes are trivial
-decodes), no roaring, no aws-sdk. `quick-xml` parses S3 list + multipart
-responses (pull-parser does charset decode + entity unescape, replacing
-earlier hand-rolled string extraction). Single crypto stack on aws-lc-rs
+decodes), no aws-sdk. `roaring` is the one earned exception (+`bytemuck`,
+both pure-Rust leaves): a stdlib `BTreeSet` can't compress dense deltas,
+so it broke the no-overcommit budget by ~100x on large rewrites (see
+Delta backups). `quick-xml` parses S3 list + multipart responses
+(pull-parser does charset decode + entity unescape, replacing earlier
+hand-rolled string extraction). Single crypto stack on aws-lc-rs
 (rustls provider + GCS RS256), no transitive ring.

--- a/src/pg/backup/delta.rs
+++ b/src/pg/backup/delta.rs
@@ -23,10 +23,11 @@
 //! `BLOCKS_IN_REL_FILE` + intra-segment offset)
 
 use std::collections::{BTreeMap, BTreeSet, HashSet};
-use std::io::{self, Read, Write};
+use std::io::{self, Read};
 use std::sync::Arc;
 
 use anyhow::{Context, Result, anyhow};
+use roaring::RoaringBitmap;
 use thiserror::Error;
 use tokio_util::io::SyncIoBridge;
 
@@ -39,7 +40,6 @@ use crate::pg::backup::{BackupSentinelDtoV2, increment, name_from_sentinel_key};
 use crate::pg::wal::segment::{SegmentName, wal_segment_size};
 use crate::pg::walparser::{
     BlockLocation, ParsePageError, RelFileNode, WalParser, extract_locations_from_wal_file,
-    read_locations_from, write_locations_to,
 };
 use crate::storage::DynStorage;
 
@@ -69,11 +69,12 @@ pub enum DeltaError {
 }
 
 /// In-memory delta map: which blocks of which relfiles changed?
-/// `BTreeSet<u32>` per rel keeps memory bounded for sparse-delta workloads
-/// (typical delta backup touches < 1% of pages)
+/// `RoaringBitmap` per rel run/bitmap-compresses dense rewrites (VACUUM FULL,
+/// CREATE INDEX, bulk load) that balloon a `BTreeSet<u32>` to ~13 B/block;
+/// sparse OLTP deltas stay comparable. Matches wal-g's `map[RelFileNode]*roaring.Bitmap`
 #[derive(Debug, Default, Clone)]
 pub struct PagedFileDeltaMap {
-    by_rel: BTreeMap<RelFileNode, BTreeSet<u32>>,
+    by_rel: BTreeMap<RelFileNode, RoaringBitmap>,
 }
 
 impl PagedFileDeltaMap {
@@ -86,7 +87,7 @@ impl PagedFileDeltaMap {
     }
 
     pub fn len(&self) -> usize {
-        self.by_rel.values().map(|s| s.len()).sum()
+        self.by_rel.values().map(|s| s.len() as usize).sum()
     }
 
     pub fn add_location(&mut self, loc: BlockLocation) {
@@ -111,7 +112,7 @@ impl PagedFileDeltaMap {
         let seg_id = get_rel_file_id_from(path)?;
         let lo = seg_id as u32 * BLOCKS_IN_REL_FILE;
         let hi = lo.saturating_add(BLOCKS_IN_REL_FILE);
-        let shifted: BTreeSet<u32> = blocks.range(lo..hi).map(|&b| b - lo).collect();
+        let shifted: BTreeSet<u32> = blocks.range(lo..hi).map(|b| b - lo).collect();
         Ok(Some(shifted))
     }
 
@@ -120,7 +121,7 @@ impl PagedFileDeltaMap {
     pub fn locations(&self) -> Vec<BlockLocation> {
         let mut out = Vec::with_capacity(self.len());
         for (rel, blocks) in &self.by_rel {
-            for &b in blocks {
+            for b in blocks {
                 out.push(BlockLocation {
                     rel: *rel,
                     block_no: b,
@@ -131,44 +132,11 @@ impl PagedFileDeltaMap {
     }
 }
 
-/// On-disk delta file: aggregated block locations + parser state for the
-/// cross-segment record stitching
-pub struct DeltaFile {
-    pub locations: Vec<BlockLocation>,
-    pub wal_parser: WalParser,
-}
-
-impl DeltaFile {
-    pub fn new(wal_parser: WalParser) -> Self {
-        Self {
-            locations: Vec::new(),
-            wal_parser,
-        }
-    }
-
-    /// wal-g `DeltaFile.Save`: write tuples (zero-terminated) then parser state
-    pub fn save<W: Write>(&self, mut w: W) -> Result<(), DeltaError> {
-        write_locations_to(&mut w, &self.locations)?;
-        self.wal_parser.save(&mut w)?;
-        Ok(())
-    }
-
-    /// Serialized byte length, for `Vec::with_capacity`. Must track `save`:
-    /// 16-byte tuples + 16-byte terminal sentinel + u32 parser len + parser data
-    pub fn serialized_len(&self) -> usize {
-        self.locations.len() * 16 + 16 + 4 + self.wal_parser.current_record_data().len()
-    }
-
-    pub fn load<R: Read>(mut r: R) -> Result<Self, DeltaError> {
-        let locations = read_locations_from(&mut r)
-            .map_err(|e| DeltaError::Io(io::Error::other(e.to_string())))?;
-        let wal_parser = WalParser::load(&mut r)?;
-        Ok(Self {
-            locations,
-            wal_parser,
-        })
-    }
-}
+// On-disk sidecar format (wal-g `DeltaFile`): location tuples, all-zero
+// terminator, then `WalParser` state (u32 len + bytes). Never materialized as
+// a struct — `wal_delta::record_segment` writes it append-only and
+// `fold_sidecar_into_map` streams it tuple-by-tuple, so neither side holds the
+// whole group's locations in memory
 
 // ─── path → RelFileNode parsing ─────────────────────────────────────────────
 
@@ -566,19 +534,18 @@ async fn build_delta_map_from_sidecars(
     let mut g = first_used_delta;
     while g < last_complete_group {
         let name = delta_group_name(timeline, g, seg_size);
-        let df = get_delta_file(settings, storage, &name, compression)
+        delta = fold_sidecar_into_map(settings, storage, &name, compression, delta)
             .await
-            .with_context(|| format!("delta sidecar {name}"))?;
-        delta.add_locations(df.locations);
+            .with_context(|| format!("delta sidecar {name}"))?
+            .0;
         g += n;
     }
     // Last complete group: its locations + parser seed for the tail walk
     let last_name = delta_group_name(timeline, last_complete_group, seg_size);
-    let last_df = get_delta_file(settings, storage, &last_name, compression)
+    let (d, mut parser) = fold_sidecar_into_map(settings, storage, &last_name, compression, delta)
         .await
         .with_context(|| format!("delta sidecar {last_name}"))?;
-    delta.add_locations(last_df.locations);
-    let mut parser = last_df.wal_parser;
+    delta = d;
 
     // Trailing partial group: raw WAL from the group start up to end_lsn
     let tail_first = first_not_used_delta;
@@ -593,27 +560,58 @@ async fn build_delta_map_from_sidecars(
     Ok(delta)
 }
 
-/// Fetch + decode a `<group>_delta` sidecar from `wal_005/` into a `DeltaFile`
-async fn get_delta_file(
+/// Fetch a `<group>_delta` sidecar from `wal_005/` and fold its location tuples
+/// straight into `map`, returning the trailing `WalParser` state. Streams 16-byte
+/// tuples through a `SyncIoBridge` so the group's locations are never collected
+/// into a `Vec` — they land in the roaring map a tuple at a time
+async fn fold_sidecar_into_map(
     settings: &crate::config::Settings,
     storage: &DynStorage,
     group_name: &str,
     compression: compression::Method,
-) -> Result<DeltaFile> {
-    use tokio::io::AsyncReadExt;
+    map: PagedFileDeltaMap,
+) -> Result<(PagedFileDeltaMap, WalParser)> {
     let key = delta_storage_key(group_name, compression);
     let r = storage
         .get(&key)
         .await
         .with_context(|| format!("get {key}"))?;
     let decrypted = settings.decrypt(r);
-    let mut decoded = compression::decode(compression, decrypted);
-    let mut buf = Vec::new();
-    decoded
-        .read_to_end(&mut buf)
+    let decoded = compression::decode(compression, decrypted);
+    tokio::task::spawn_blocking(move || fold_sidecar_stream(decoded, map))
         .await
-        .with_context(|| format!("read {key}"))?;
-    DeltaFile::load(buf.as_slice()).with_context(|| format!("decode {key}"))
+        .context("join sidecar fold")?
+        .with_context(|| format!("decode {key}"))
+}
+
+/// Sync side of [`fold_sidecar_into_map`]: read tuples until the all-zero
+/// terminator (or EOF), then the parser state
+fn fold_sidecar_stream(
+    decoded: compression::AsyncReader,
+    mut map: PagedFileDeltaMap,
+) -> Result<(PagedFileDeltaMap, WalParser)> {
+    let mut r = SyncIoBridge::new(decoded);
+    let mut buf = [0u8; 16];
+    loop {
+        match r.read_exact(&mut buf) {
+            Ok(()) => {}
+            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => {
+                return Ok((map, WalParser::new()));
+            }
+            Err(e) => return Err(anyhow::Error::from(e).context("read sidecar tuple")),
+        }
+        let loc = BlockLocation::new(
+            u32::from_le_bytes(buf[0..4].try_into().unwrap()),
+            u32::from_le_bytes(buf[4..8].try_into().unwrap()),
+            u32::from_le_bytes(buf[8..12].try_into().unwrap()),
+            u32::from_le_bytes(buf[12..16].try_into().unwrap()),
+        );
+        if loc.is_terminal() {
+            let parser = WalParser::load(&mut r).context("load sidecar parser state")?;
+            return Ok((map, parser));
+        }
+        map.add_location(loc);
+    }
 }
 
 /// Full raw-WAL walk of `[start_lsn, end_lsn)`: parse every segment. Fallback
@@ -835,26 +833,27 @@ mod tests {
     }
 
     #[test]
-    fn delta_file_round_trip() {
-        let wp = WalParser::new();
+    fn sidecar_format_round_trip() {
+        // Bytes the streaming writer emits: tuples + terminator + parser state
+        use crate::pg::walparser::{read_locations_from, write_locations_to};
         let mut buf = Vec::new();
-        wp.save(&mut buf).unwrap();
-        let wp_reloaded = WalParser::load(buf.as_slice()).unwrap();
+        write_locations_to(
+            &mut buf,
+            &[
+                BlockLocation::new(DEFAULT_SPC_NODE, 16384, 16385, 7),
+                BlockLocation::new(DEFAULT_SPC_NODE, 16384, 16386, 0),
+            ],
+        )
+        .unwrap();
+        WalParser::new().save(&mut buf).unwrap();
 
-        let mut df = DeltaFile::new(wp_reloaded);
-        df.locations
-            .push(BlockLocation::new(DEFAULT_SPC_NODE, 16384, 16385, 7));
-        df.locations
-            .push(BlockLocation::new(DEFAULT_SPC_NODE, 16384, 16386, 0));
-
-        let mut out = Vec::new();
-        df.save(&mut out).unwrap();
-
-        let df2 = DeltaFile::load(out.as_slice()).unwrap();
-        assert_eq!(df2.locations.len(), 2);
-        assert_eq!(df2.locations[0].block_no, 7);
-        assert_eq!(df2.locations[1].block_no, 0);
-        assert!(df2.wal_parser.current_record_data().is_empty());
+        let mut cur = buf.as_slice();
+        let locs = read_locations_from(&mut cur).unwrap();
+        assert_eq!(locs.len(), 2);
+        assert_eq!(locs[0].block_no, 7);
+        assert_eq!(locs[1].block_no, 0);
+        let wp = WalParser::load(&mut cur).unwrap();
+        assert!(wp.current_record_data().is_empty());
     }
 
     #[test]
@@ -922,18 +921,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_delta_file_reads_sidecar() {
+    async fn fold_sidecar_into_map_reads_blocks() {
+        use crate::pg::walparser::write_locations_to;
         use crate::storage::fs::FsStorage;
         let dir = tempfile::tempdir().unwrap();
         let storage: DynStorage = Arc::new(FsStorage::new(dir.path()).unwrap());
         let settings = crate::config::Settings::default();
         let method = compression::Method::None;
 
-        let mut df = DeltaFile::new(WalParser::new());
-        df.locations
-            .push(BlockLocation::new(DEFAULT_SPC_NODE, 16384, 16385, 7));
+        // Sidecar bytes: one tuple + terminator + parser state
         let mut raw = Vec::new();
-        df.save(&mut raw).unwrap();
+        write_locations_to(
+            &mut raw,
+            &[BlockLocation::new(DEFAULT_SPC_NODE, 16384, 16385, 7)],
+        )
+        .unwrap();
+        WalParser::new().save(&mut raw).unwrap();
 
         let group = delta_group_name(1, 0, DEFAULT_WAL_SEG_SIZE);
         let key = delta_storage_key(&group, method);
@@ -941,10 +944,17 @@ mod tests {
         let r: crate::compression::AsyncReader = Box::pin(std::io::Cursor::new(raw));
         storage.put(&key, r, Some(len)).await.unwrap();
 
-        let got = get_delta_file(&settings, &storage, &group, method)
-            .await
-            .unwrap();
-        assert_eq!(got.locations.len(), 1);
-        assert_eq!(got.locations[0].block_no, 7);
+        let (map, parser) = fold_sidecar_into_map(
+            &settings,
+            &storage,
+            &group,
+            method,
+            PagedFileDeltaMap::new(),
+        )
+        .await
+        .unwrap();
+        let blocks = map.blocks_for("base/16384/16385").unwrap().unwrap();
+        assert_eq!(blocks.into_iter().collect::<Vec<_>>(), vec![7u32]);
+        assert!(parser.current_record_data().is_empty());
     }
 }

--- a/src/pg/backup/wal_delta.rs
+++ b/src/pg/backup/wal_delta.rs
@@ -29,11 +29,10 @@ use anyhow::{Context, Result, anyhow, bail};
 use crate::compression;
 use crate::config::Settings;
 use crate::pg::WAL_FOLDER;
-use crate::pg::backup::delta::DeltaFile;
 use crate::pg::wal::segment::{SegmentName, wal_segment_size};
 use crate::pg::walparser::{
     BlockLocation, WAL_PAGE_SIZE, WalParser, XLP_PAGE_MAGIC_PG14, extract_block_locations,
-    parse_record_from_bytes,
+    parse_record_from_bytes, write_location_tuples, write_locations_to,
 };
 use crate::storage::DynStorage;
 
@@ -332,20 +331,25 @@ async fn save_part(folder: &Path, group_name: &str, part: &PartFile) -> Result<(
         .context("write part file")
 }
 
-async fn load_local_delta(folder: &Path, group_name: &str) -> Result<DeltaFile> {
-    match tokio::fs::read(local_delta_path(folder, group_name)).await {
-        Ok(buf) => Ok(DeltaFile::load(buf.as_slice()).context("decode local delta file")?),
-        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(DeltaFile::new(WalParser::new())),
-        Err(e) => Err(e).context("read local delta file"),
+/// Append a segment's location tuples to the running `<group>` working file.
+/// Append-only: the file accumulates raw tuples across the group, so recording
+/// holds at most one segment's locations rather than the whole group's
+async fn append_local_delta(folder: &Path, group_name: &str, locs: &[BlockLocation]) -> Result<()> {
+    if locs.is_empty() {
+        return Ok(());
     }
-}
-
-async fn save_local_delta(folder: &Path, group_name: &str, delta: &DeltaFile) -> Result<()> {
-    let mut buf = Vec::with_capacity(delta.serialized_len());
-    delta.save(&mut buf).context("encode local delta file")?;
-    tokio::fs::write(local_delta_path(folder, group_name), &buf)
+    use tokio::io::AsyncWriteExt;
+    let mut buf = Vec::with_capacity(locs.len() * 16);
+    write_location_tuples(&mut buf, locs).context("encode location tuples")?;
+    let mut f = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(local_delta_path(folder, group_name))
         .await
-        .context("write local delta file")
+        .context("open local delta file")?;
+    f.write_all(&buf).await.context("append local delta file")?;
+    f.flush().await.context("flush local delta file")?;
+    Ok(())
 }
 
 async fn remove_group_files(folder: &Path, group_name: &str) {
@@ -361,17 +365,47 @@ async fn remove_group_files(folder: &Path, group_name: &str) {
     }
 }
 
-async fn upload_delta(
+/// Finalize the working file (append boundary-record tuples, the terminator,
+/// then the parser seed) and stream it to the bucket compressed+encrypted.
+/// Reads from the on-disk file rather than a buffer, so the group's locations
+/// are never held in memory
+async fn finalize_and_upload(
     settings: &Settings,
     storage: &DynStorage,
+    folder: &Path,
     group_name: &str,
-    delta: &DeltaFile,
+    combined: &[BlockLocation],
+    parser: &WalParser,
 ) -> Result<()> {
-    let mut buf = Vec::with_capacity(delta.serialized_len());
-    delta.save(&mut buf).context("encode delta sidecar")?;
+    use tokio::io::AsyncWriteExt;
+    // tuples + all-zero terminator + parser state, mirroring wal-g's DeltaFile
+    let mut tail = Vec::new();
+    write_locations_to(&mut tail, combined).context("encode boundary tuples")?;
+    parser.save(&mut tail).context("encode parser state")?;
+    let path = local_delta_path(folder, group_name);
+    {
+        let mut f = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .await
+            .context("open local delta file")?;
+        f.write_all(&tail)
+            .await
+            .context("finalize local delta file")?;
+        f.flush().await.context("flush local delta file")?;
+    }
+
+    let size = tokio::fs::metadata(&path)
+        .await
+        .context("stat local delta file")?
+        .len();
+    let file = tokio::fs::File::open(&path)
+        .await
+        .context("reopen local delta file")?;
     let method = settings.compression;
     let key = delta_storage_key(group_name, method);
-    let reader: compression::AsyncReader = Box::pin(std::io::Cursor::new(buf));
+    let reader: compression::AsyncReader = Box::pin(file);
     let compressed = compression::encode(method, reader, settings.compression_level);
     let body = settings.encrypt(compressed);
     storage
@@ -380,8 +414,7 @@ async fn upload_delta(
         .with_context(|| format!("put {key}"))?;
     tracing::info!(
         target = "wal_push",
-        "uploaded delta sidecar {key} ({} location(s))",
-        delta.locations.len()
+        "uploaded delta sidecar {key} ({size} bytes)"
     );
     Ok(())
 }
@@ -434,8 +467,7 @@ pub async fn record_segment(
     part.heads[pos] = Some(rec.trailing_head.clone());
     part.head_magics[pos] = Some(rec.page_magic);
 
-    let mut delta = load_local_delta(&folder, &group_name).await?;
-    delta.locations.extend(rec.locations);
+    append_local_delta(&folder, &group_name, &rec.locations).await?;
 
     // Last segment of the group also seeds the next group's prev_head
     if pos == WAL_FILES_IN_DELTA as usize - 1 {
@@ -447,18 +479,17 @@ pub async fn record_segment(
     }
 
     if part.is_complete() {
-        delta.locations.extend(part.combine()?);
+        let combined = part.combine()?;
         // Resume point for the consumer's cross-group stitching
         let last_head = part.heads[WAL_FILES_IN_DELTA as usize - 1]
             .clone()
             .unwrap_or_default();
-        delta.wal_parser = WalParser::from_current_record_head(last_head);
-        upload_delta(settings, storage, &group_name, &delta).await?;
+        let parser = WalParser::from_current_record_head(last_head);
+        finalize_and_upload(settings, storage, &folder, &group_name, &combined, &parser).await?;
         remove_group_files(&folder, &group_name).await;
         tracing::debug!(target = "wal_push", "delta group {group_name} complete");
     } else {
         save_part(&folder, &group_name, &part).await?;
-        save_local_delta(&folder, &group_name, &delta).await?;
     }
     Ok(())
 }

--- a/src/pg/wal_summaries.rs
+++ b/src/pg/wal_summaries.rs
@@ -25,6 +25,7 @@ use std::fs::{self, File};
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 
+use roaring::RoaringBitmap;
 use thiserror::Error;
 
 use crate::pg::backup::delta::PagedFileDeltaMap;
@@ -121,14 +122,13 @@ struct RelForkKey {
 struct RelForkState {
     /// Set of changed block numbers in this rel/fork. Ranges past the
     /// observed limit_block get pruned via `prune_above`
-    blocks: std::collections::BTreeSet<u32>,
+    blocks: RoaringBitmap,
 }
 
 impl RelForkState {
-    /// wal-g semantics: remove everything `>= limit`. BTreeSet::split_off
-    /// returns the upper portion `[limit..)`, discarding it via `_`
+    /// wal-g semantics: remove everything `>= limit` (the PR's `RemoveRange`)
     fn prune_above(&mut self, limit: u32) {
-        let _ = self.blocks.split_off(&limit);
+        self.blocks.remove_range(limit..);
     }
 }
 
@@ -601,7 +601,7 @@ mod tests {
             fork_num: MAIN_FORK_NUM,
         };
         let st = state.get(&key).unwrap();
-        let got: Vec<u32> = st.blocks.iter().copied().collect();
+        let got: Vec<u32> = st.blocks.iter().collect();
         assert_eq!(got, vec![10, 20, 30]);
     }
 
@@ -633,7 +633,7 @@ mod tests {
             fork_num: MAIN_FORK_NUM,
         };
         let st = state.get(&key).unwrap();
-        let got: Vec<u32> = st.blocks.iter().copied().collect();
+        let got: Vec<u32> = st.blocks.iter().collect();
         assert_eq!(got, vec![0, 1, 15, 16, 17]);
     }
 
@@ -671,7 +671,7 @@ mod tests {
             fork_num: MAIN_FORK_NUM,
         };
         let st = state.get(&key).unwrap();
-        let got: Vec<u32> = st.blocks.iter().copied().collect();
+        let got: Vec<u32> = st.blocks.iter().collect();
         assert_eq!(got, vec![5, 10]);
     }
 

--- a/src/pg/walparser/mod.rs
+++ b/src/pg/walparser/mod.rs
@@ -25,7 +25,7 @@ mod types;
 pub use parse::{ExtractError, ParseError, extract_block_locations, parse_record_from_bytes};
 pub use state::{
     ParsePageError, ReadLocationsError, WalParser, extract_locations_from_wal_file,
-    read_locations_from, write_locations_to,
+    read_locations_from, write_location_tuples, write_locations_to,
 };
 pub use types::{
     BKP_BLOCK_HAS_IMAGE, BKP_IMAGE_COMPRESS_LZ4, BKP_IMAGE_COMPRESS_MASK_PG15,

--- a/src/pg/walparser/state.rs
+++ b/src/pg/walparser/state.rs
@@ -456,15 +456,22 @@ fn read_exact_or_eof<R: Read>(r: &mut R, buf: &mut [u8]) -> io::Result<ReadStatu
 
 // ─── delta file BlockLocation list I/O (wal-g block_location_writer/reader) ─
 
-/// Write a list of locations as 16-byte LE u32×4 tuples + an all-zero
-/// terminator. Format consumed by wal-g's `ReadLocationsFrom`
-pub fn write_locations_to<W: Write>(mut w: W, locations: &[BlockLocation]) -> io::Result<()> {
+/// Write locations as 16-byte LE u32×4 tuples, no terminator. Lets a sidecar
+/// be built by appending segment fragments before the terminator is written
+pub fn write_location_tuples<W: Write>(mut w: W, locations: &[BlockLocation]) -> io::Result<()> {
     for loc in locations {
         w.write_all(&loc.rel.spc_node.to_le_bytes())?;
         w.write_all(&loc.rel.db_node.to_le_bytes())?;
         w.write_all(&loc.rel.rel_node.to_le_bytes())?;
         w.write_all(&loc.block_no.to_le_bytes())?;
     }
+    Ok(())
+}
+
+/// Write a list of locations as 16-byte LE u32×4 tuples + an all-zero
+/// terminator. Format consumed by wal-g's `ReadLocationsFrom`
+pub fn write_locations_to<W: Write>(mut w: W, locations: &[BlockLocation]) -> io::Result<()> {
+    write_location_tuples(&mut w, locations)?;
     w.write_all(&[0u8; 16])?;
     Ok(())
 }


### PR DESCRIPTION
avoids allocating over 100MB in situations like pg_repack