### PR TITLE
fix: conditionally compile std::os::linux code, so it can be built on MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,10 @@ jobs:
         working-directory: bench/tools
 
   test:
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -70,8 +70,11 @@ pub async fn serve(
     });
 
     spawn_sigusr1_listener();
-    systemd::notify("READY=1");
-    systemd::spawn_watchdog();
+    #[cfg(target_os = "linux")]
+    {
+        systemd::notify("READY=1");
+        systemd::spawn_watchdog();
+    }
 
     loop {
         let (stream, _) = listener.accept().await?;

--- a/src/daemon/systemd.rs
+++ b/src/daemon/systemd.rs
@@ -5,6 +5,8 @@
 //! no-ops when walrus is not run under systemd. Mirrors wal-g's
 //! SendSdNotify, sized down to readiness + watchdog keep-alive
 
+#![cfg(target_os = "linux")]
+
 use std::ffi::OsStr;
 use std::os::unix::ffi::OsStrExt;
 use std::time::Duration;


### PR DESCRIPTION
Fixes compilation & test issues on MacOS:

```
ostinru@ostinru-osx wal-rus % cargo test
   Compiling wal-rus v0.2.1 (/Users/ostinru/development/wal-rus)
error[E0433]: cannot find `linux` in `os`
  --> src/daemon/systemd.rs:32:22
   |
32 |         use std::os::linux::net::SocketAddrExt;
   |                      ^^^^^ could not find `linux` in `os`
   |
```