### PR TITLE
pg::wal::receive: make lsn_to_timeline public

### DIFF
--- a/src/pg/wal/receive.rs
+++ b/src/pg/wal/receive.rs
@@ -650,7 +650,7 @@ async fn get_start_timeline(
 /// `<tli>\t<switch_lsn>\t<comment>`; a switch to `tli+1` happened at
 /// `switch_lsn`, so the first row whose switch LSN exceeds `lsn` names its
 /// timeline, else the file's own (wal-g LSNToTimeLine)
-fn lsn_to_timeline(content: &[u8], lsn: u64, file_timeline: u32) -> u32 {
+pub fn lsn_to_timeline(content: &[u8], lsn: u64, file_timeline: u32) -> u32 {
     let text = String::from_utf8_lossy(content);
     let mut rows: Vec<(u32, u64)> = Vec::new();
     for line in text.lines() {


### PR DESCRIPTION
## What

Make the existing `lsn_to_timeline` in `pg::wal::receive` `pub` so external WAL-processing tools can reuse it.

```rust
pub fn lsn_to_timeline(content: &[u8], lsn: u64, file_timeline: u32) -> u32
```

## Why

Resolving *which timeline owns a resume LSN* by walking a `TIMELINE_HISTORY` response is a standard step for anything that streams replication and can resume behind a timeline fork. `lsn_to_timeline` already implements it (mirrors wal-g's `LSNToTimeLine`), but it was private, so the **wal-listener** synchronous receiver had to duplicate it byte-for-byte. This exposes the single implementation and lets that copy be deleted.

Follow-up to #19 ("Expose replication + object-storage primitives for building WAL-processing tools").

## Notes

- No behavior change — pure visibility (`fn` → `pub fn`) plus a doc note.
- The existing `lsn_to_timeline_walks_history` unit test still covers it.
- The module path is already public (`pub mod pg` → `pub mod wal` → `pub mod receive`), so it's reachable as `walrus::pg::wal::receive::lsn_to_timeline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)