### PR TITLE
[WIP] Keyless per-pod cloud identity for S3 and GCS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2275,7 +2275,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wal-rus"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wal-rus"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.90"
 description = "Rust port of wal-g for PostgreSQL, optimized for no-overcommit hosts"

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -65,9 +65,11 @@ Profile/shared-credentials files and STS web-identity
 
 ### GCS
 
-Service-account JWT (RS256 via aws-lc-rs) exchanged for an OAuth bearer,
-cached until 60 s before expiry. Uploads stream via `uploadType=media`.
-Resumable uploads and metadata-server auth not implemented.
+Service-account JWT (RS256 via aws-lc-rs) exchanged for an OAuth bearer, or —
+when `GOOGLE_APPLICATION_CREDENTIALS` is unset — a bearer straight from the
+GKE/GCE metadata server (Workload Identity, no key material). Either way cached
+until 60 s before expiry. Uploads stream via `uploadType=media`. Resumable
+uploads not implemented.
 
 ### Retry classification
 

--- a/docs/WALG_COMPAT.md
+++ b/docs/WALG_COMPAT.md
@@ -163,9 +163,6 @@ Accepted by wal-g Postgres config but not used by PG code paths:
 - `AWS_SHARED_CREDENTIALS_FILE`
 - `AWS_CONFIG_FILE`
 - `AWS_CA_BUNDLE`
-- `AWS_ROLE_ARN`
-- `AWS_ROLE_SESSION_NAME`
-- `AWS_WEB_IDENTITY_TOKEN_FILE`
 - `AWS_DUAL_STACK`
 - `WALG_S3_CA_CERT_FILE`
 - `S3_CA_CERT_FILE`
@@ -205,6 +202,16 @@ Accepted by wal-g Postgres config but not used by PG code paths:
 - `S3_ENABLE_VERSIONING`
 - `S3_DELETE_BATCH_SIZE`
 
+Credential resolution follows the AWS SDK chain — static keys, then web-identity
+(`AWS_WEB_IDENTITY_TOKEN_FILE` + `AWS_ROLE_ARN`, optional
+`AWS_ROLE_SESSION_NAME` / `AWS_ENDPOINT_URL_STS`), then the container
+credentials endpoint (`AWS_CONTAINER_CREDENTIALS_FULL_URI` or
+`..._RELATIVE_URI`, with `AWS_CONTAINER_AUTHORIZATION_TOKEN[_FILE]`), then EC2
+IMDS. Not covered: shared config/profile files, SSO, `credential_process`, and
+`AWS_ROLE_ARN` on its own — wal-g would assume that role using ambient
+credentials, whereas walrus honors `AWS_ROLE_ARN` only together with a
+web-identity token file.
+
 ### GCS storage
 
 - `WALE_GS_PREFIX`
@@ -214,7 +221,10 @@ Accepted by wal-g Postgres config but not used by PG code paths:
 - `GCS_MAX_CHUNK_SIZE`
 - `GCS_MAX_RETRIES`
 
-GCE/GKE metadata-server auth is not implemented.
+Auth matches Google ADC apart from the gcloud well-known credentials file:
+`GOOGLE_APPLICATION_CREDENTIALS` selects the service-account JSON, and its
+absence selects the GKE/GCE metadata server (Workload Identity), with
+`GCE_METADATA_HOST` honored as the host override.
 
 ### Storage backends not implemented
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -259,11 +259,17 @@ fn storage_from_uri(vars: &Vars, uri: &str, src: &StorageSettings) -> Result<Sto
             _ => None,
         }
         .or_else(|| gcs_endpoint(vars));
+        let metadata_endpoint = match src {
+            StorageSettings::Gcs(c) => c.metadata_endpoint.clone(),
+            _ => None,
+        }
+        .or_else(|| vars.get("GCE_METADATA_HOST"));
         return Ok(StorageSettings::Gcs(gcs::GcsConfig {
             bucket,
             prefix,
             credentials_path,
             endpoint,
+            metadata_endpoint,
         }));
     }
     // bare path falls back to fs
@@ -304,7 +310,7 @@ fn s3_config(
         .or_else(|| vars.get("AWS_REGION"))
         .or_else(|| vars.get("WALG_S3_REGION"))
         .unwrap_or_else(|| "us-east-1".into());
-    let creds = s3_credentials(vars, src)?;
+    let creds = s3_credentials(vars, src, &region)?;
     let endpoint = src
         .and_then(|c| c.endpoint.clone())
         .or_else(|| vars.get("AWS_ENDPOINT_URL"))
@@ -335,11 +341,16 @@ fn force_path_style(vars: &Vars, endpoint_set: bool) -> Result<bool> {
     Ok(endpoint_set)
 }
 
-/// Pick a credential source: inherit `src`, else explicit static env keys,
-/// else the EC2 metadata service. IMDS is skipped (surfacing the missing-keys
-/// error) when AWS_EC2_METADATA_DISABLED is set. One static key without the
-/// other is a hard error rather than a silent IMDS fallback
-fn s3_credentials(vars: &Vars, src: Option<&s3::S3Config>) -> Result<s3::CredentialSource> {
+/// Pick a credential source, in the same order as the AWS SDKs: inherit `src`,
+/// else explicit static env keys, else ambient per-pod identity (web-identity
+/// then container credentials), else the EC2 metadata service. IMDS is skipped
+/// (surfacing the missing-keys error) when AWS_EC2_METADATA_DISABLED is set. One
+/// static key without the other is a hard error rather than a silent fallback
+fn s3_credentials(
+    vars: &Vars,
+    src: Option<&s3::S3Config>,
+    region: &str,
+) -> Result<s3::CredentialSource> {
     if let Some(c) = src {
         return Ok(c.creds.clone());
     }
@@ -349,26 +360,66 @@ fn s3_credentials(vars: &Vars, src: Option<&s3::S3Config>) -> Result<s3::Credent
     let secret_key = vars
         .get("AWS_SECRET_ACCESS_KEY")
         .or_else(|| vars.get("AWS_SECRET_KEY"));
-    match (access_key, secret_key) {
-        (Some(access_key), Some(secret_key)) => Ok(s3::CredentialSource::Static(s3::Credentials {
-            access_key,
-            secret_key,
+    if let (Some(access_key), Some(secret_key)) = (&access_key, &secret_key) {
+        return Ok(s3::CredentialSource::Static(s3::Credentials {
+            access_key: access_key.clone(),
+            secret_key: secret_key.clone(),
             session_token: vars.get("AWS_SESSION_TOKEN"),
             expires_at: None,
-        })),
-        (None, None) if vars.bool("AWS_EC2_METADATA_DISABLED", false)? => {
-            Err(anyhow!("AWS_ACCESS_KEY_ID not set and IMDS disabled"))
-        }
-        (None, None) => {
-            let endpoint = vars.get("AWS_EC2_METADATA_SERVICE_ENDPOINT");
-            Ok(s3::CredentialSource::Imds(Arc::new(
-                s3::ImdsProvider::new(endpoint).map_err(|e| anyhow!("{e}"))?,
-            )))
-        }
-        _ => Err(anyhow!(
-            "incomplete static credentials: set both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY"
-        )),
+        }));
     }
+    if access_key.is_some() != secret_key.is_some() {
+        bail!(
+            "incomplete static credentials: set both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY"
+        );
+    }
+    if let Some(kind) = ambient_kind(vars, region) {
+        return Ok(s3::CredentialSource::Ambient(Arc::new(
+            s3::AmbientProvider::new(kind).map_err(|e| anyhow!("{e}"))?,
+        )));
+    }
+    if vars.bool("AWS_EC2_METADATA_DISABLED", false)? {
+        bail!("AWS_ACCESS_KEY_ID not set and IMDS disabled");
+    }
+    let endpoint = vars.get("AWS_EC2_METADATA_SERVICE_ENDPOINT");
+    Ok(s3::CredentialSource::Imds(Arc::new(
+        s3::ImdsProvider::new(endpoint).map_err(|e| anyhow!("{e}"))?,
+    )))
+}
+
+/// Ambient (keyless) per-pod identity, preferring web-identity over container
+/// credentials like the AWS SDKs do. On EKS/GKE the platform injects these vars
+/// itself once the pod runs under a bound ServiceAccount
+fn ambient_kind(vars: &Vars, region: &str) -> Option<s3::AmbientKind> {
+    // IRSA: the EKS mutating webhook projects the token and sets both vars
+    if let (Some(token_file), Some(role_arn)) = (
+        vars.get("AWS_WEB_IDENTITY_TOKEN_FILE"),
+        vars.get("AWS_ROLE_ARN"),
+    ) {
+        return Some(s3::AmbientKind::WebIdentity {
+            sts_endpoint: vars
+                .get("AWS_ENDPOINT_URL_STS")
+                .unwrap_or_else(|| format!("https://sts.{region}.amazonaws.com")),
+            role_arn,
+            session_name: vars
+                .get("AWS_ROLE_SESSION_NAME")
+                .unwrap_or_else(|| "wal-rus".into()),
+            token_file,
+        });
+    }
+    // EKS Pod Identity sets FULL_URI; ECS sets the relative form
+    let url = vars.get("AWS_CONTAINER_CREDENTIALS_FULL_URI").or_else(|| {
+        vars.get("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+            .map(|rel| {
+                let sep = if rel.starts_with('/') { "" } else { "/" };
+                format!("http://169.254.170.2{sep}{rel}")
+            })
+    })?;
+    Some(s3::AmbientKind::Container {
+        url,
+        token_file: vars.get("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE"),
+        static_token: vars.get("AWS_CONTAINER_AUTHORIZATION_TOKEN"),
+    })
 }
 
 impl DeltaSettings {
@@ -410,6 +461,7 @@ fn detect_storage(vars: &Vars) -> Result<StorageSettings> {
             prefix,
             credentials_path: vars.get("GOOGLE_APPLICATION_CREDENTIALS"),
             endpoint: gcs_endpoint(vars),
+            metadata_endpoint: vars.get("GCE_METADATA_HOST"),
         }));
     }
     bail!("no storage configured: set WALG_FILE_PREFIX, WALG_S3_PREFIX, or WALG_GS_PREFIX")
@@ -704,6 +756,7 @@ mod tests {
                 prefix: "srcp".into(),
                 credentials_path: Some("/src/sa.json".into()),
                 endpoint: None,
+                metadata_endpoint: None,
             });
             match storage_from_uri(&Vars::default(), "gs://dstb/dst/pre", &src).unwrap() {
                 StorageSettings::Gcs(c) => {
@@ -821,6 +874,12 @@ mod tests {
                 ("AWS_SECRET_ACCESS_KEY", None),
                 ("AWS_SECRET_KEY", None),
                 ("AWS_EC2_METADATA_DISABLED", None),
+                // a real IRSA / Pod-Identity host has these set, which would
+                // route ahead of IMDS
+                ("AWS_WEB_IDENTITY_TOKEN_FILE", None),
+                ("AWS_ROLE_ARN", None),
+                ("AWS_CONTAINER_CREDENTIALS_FULL_URI", None),
+                ("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", None),
             ]);
             match detect_storage(&Vars::default()).unwrap() {
                 StorageSettings::S3(c) => {
@@ -840,6 +899,10 @@ mod tests {
                 ("AWS_SECRET_ACCESS_KEY", None),
                 ("AWS_SECRET_KEY", None),
                 ("AWS_EC2_METADATA_DISABLED", Some("true")),
+                ("AWS_WEB_IDENTITY_TOKEN_FILE", None),
+                ("AWS_ROLE_ARN", None),
+                ("AWS_CONTAINER_CREDENTIALS_FULL_URI", None),
+                ("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", None),
             ]);
             assert!(detect_storage(&Vars::default()).is_err());
         }
@@ -914,6 +977,7 @@ mod tests {
                 prefix: "gp".into(),
                 credentials_path: Some(sa.to_string_lossy().into()),
                 endpoint: None,
+                metadata_endpoint: None,
             }),
             RetryPolicy::default(),
         )
@@ -1014,15 +1078,116 @@ mod tests {
 
     #[test]
     fn s3_credentials_incomplete_static_is_error() {
-        // access key without its secret is a hard error, never a silent IMDS
-        // fallback
+        // access key without its secret is a hard error, never a silent fallback
+        // to IMDS or ambient identity
         let _g = EnvGuard::new(&[
             ("AWS_ACCESS_KEY_ID", Some("AKIAEXAMPLE")),
             ("AWS_ACCESS_KEY", None),
             ("AWS_SECRET_ACCESS_KEY", None),
             ("AWS_SECRET_KEY", None),
+            ("AWS_WEB_IDENTITY_TOKEN_FILE", None),
+            ("AWS_ROLE_ARN", None),
+            ("AWS_CONTAINER_CREDENTIALS_FULL_URI", None),
+            ("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", None),
         ]);
-        assert!(s3_credentials(&Vars::default(), None).is_err());
+        assert!(s3_credentials(&Vars::default(), None, "us-east-1").is_err());
+    }
+
+    /// The keyless chain: web-identity beats container creds, both beat IMDS,
+    /// and static keys still win over everything.
+    #[test]
+    fn s3_credentials_selects_ambient_sources_in_sdk_order() {
+        // web-identity needs both vars; the STS endpoint defaults per-region
+        {
+            let _g = EnvGuard::new(&[
+                ("AWS_ACCESS_KEY_ID", None),
+                ("AWS_ACCESS_KEY", None),
+                ("AWS_SECRET_ACCESS_KEY", None),
+                ("AWS_SECRET_KEY", None),
+                (
+                    "AWS_WEB_IDENTITY_TOKEN_FILE",
+                    Some("/var/run/secrets/token"),
+                ),
+                ("AWS_ROLE_ARN", Some("arn:aws:iam::1:role/tenant")),
+                ("AWS_CONTAINER_CREDENTIALS_FULL_URI", None),
+                ("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", None),
+            ]);
+            let c = s3_credentials(&Vars::default(), None, "eu-west-1").unwrap();
+            assert_eq!(c.identity(), "web-identity");
+        }
+        // AWS_ROLE_ARN alone is not enough (that would be plain assume-role,
+        // which we don't implement) -> falls through to IMDS
+        {
+            let _g = EnvGuard::new(&[
+                ("AWS_ACCESS_KEY_ID", None),
+                ("AWS_ACCESS_KEY", None),
+                ("AWS_SECRET_ACCESS_KEY", None),
+                ("AWS_SECRET_KEY", None),
+                ("AWS_WEB_IDENTITY_TOKEN_FILE", None),
+                ("AWS_ROLE_ARN", Some("arn:aws:iam::1:role/tenant")),
+                ("AWS_CONTAINER_CREDENTIALS_FULL_URI", None),
+                ("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", None),
+                ("AWS_EC2_METADATA_DISABLED", None),
+            ]);
+            let c = s3_credentials(&Vars::default(), None, "us-east-1").unwrap();
+            assert!(matches!(c, s3::CredentialSource::Imds(_)));
+        }
+        // EKS Pod Identity injects FULL_URI
+        {
+            let _g = EnvGuard::new(&[
+                ("AWS_ACCESS_KEY_ID", None),
+                ("AWS_ACCESS_KEY", None),
+                ("AWS_SECRET_ACCESS_KEY", None),
+                ("AWS_SECRET_KEY", None),
+                ("AWS_WEB_IDENTITY_TOKEN_FILE", None),
+                ("AWS_ROLE_ARN", None),
+                (
+                    "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+                    Some("http://169.254.170.23/v1/credentials"),
+                ),
+                ("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", None),
+            ]);
+            let c = s3_credentials(&Vars::default(), None, "us-east-1").unwrap();
+            assert_eq!(c.identity(), "container-creds");
+        }
+        // static keys win even with the ambient vars present
+        {
+            let _g = EnvGuard::new(&[
+                ("AWS_ACCESS_KEY_ID", Some("AKIAEXAMPLE")),
+                ("AWS_ACCESS_KEY", None),
+                ("AWS_SECRET_ACCESS_KEY", Some("sekrit")),
+                ("AWS_SECRET_KEY", None),
+                ("AWS_SESSION_TOKEN", None),
+                (
+                    "AWS_WEB_IDENTITY_TOKEN_FILE",
+                    Some("/var/run/secrets/token"),
+                ),
+                ("AWS_ROLE_ARN", Some("arn:aws:iam::1:role/tenant")),
+                ("AWS_CONTAINER_CREDENTIALS_FULL_URI", None),
+                ("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", None),
+            ]);
+            let c = s3_credentials(&Vars::default(), None, "us-east-1").unwrap();
+            assert_eq!(c.identity(), "AKIAEXAMPLE");
+        }
+    }
+
+    #[test]
+    fn container_creds_relative_uri_joins_the_ecs_link_local_base() {
+        let _g = EnvGuard::new(&[
+            ("AWS_WEB_IDENTITY_TOKEN_FILE", None),
+            ("AWS_ROLE_ARN", None),
+            ("AWS_CONTAINER_CREDENTIALS_FULL_URI", None),
+            (
+                "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+                Some("/v2/credentials/abc"),
+            ),
+        ]);
+        match ambient_kind(&Vars::default(), "us-east-1") {
+            Some(s3::AmbientKind::Container { url, .. }) => {
+                assert_eq!(url, "http://169.254.170.2/v2/credentials/abc");
+            }
+            other => panic!("expected container creds, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/storage/creds.rs
+++ b/src/storage/creds.rs
@@ -1,10 +1,17 @@
-//! S3 credential sources: long-lived keys and EC2 instance-metadata (IMDS).
+//! S3 credential sources: long-lived keys plus three temporary-credential
+//! providers, chained in the same order as the AWS SDKs.
 //!
-//! Static keys come straight from env. IMDS creds are temporary: fetched from
-//! the link-local metadata service via IMDSv2 (token-authenticated, falling
-//! back to v1 when the token PUT is refused), cached, and refreshed shortly
-//! before expiry. ECS/EKS container creds and STS web-identity are not (yet)
-//! covered; the `CredentialSource` enum leaves room for them.
+//! Static keys come straight from env. The rest are temporary: cached and
+//! refreshed shortly before expiry.
+//! - IMDS: the link-local metadata service via IMDSv2 (token-authenticated,
+//!   falling back to v1 when the token PUT is refused).
+//! - Container credentials (EKS Pod Identity / ECS): one authenticated GET
+//!   returning the same document shape as IMDS.
+//! - STS web-identity (IRSA): the projected ServiceAccount JWT exchanged for
+//!   temporary creds via AssumeRoleWithWebIdentity.
+//!
+//! The last two are ambient per-pod identity — no key material on disk — and
+//! share `AmbientProvider`, since both are a single authenticated HTTP call.
 
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
@@ -45,29 +52,34 @@ impl Credentials {
     }
 }
 
-/// How S3 obtains credentials for signing. `Static` holds keys verbatim;
-/// `Imds` fetches temporary creds from the metadata service on demand.
+/// How S3 obtains credentials for signing. `Static` holds keys verbatim; the
+/// other two fetch temporary creds on demand — `Imds` from the EC2 metadata
+/// service, `Ambient` from a per-pod identity endpoint.
 #[derive(Debug, Clone)]
 pub enum CredentialSource {
     Static(Credentials),
     Imds(Arc<ImdsProvider>),
+    Ambient(Arc<AmbientProvider>),
 }
 
 impl CredentialSource {
-    /// Current credentials, fetching/refreshing from IMDS when needed
+    /// Current credentials, fetching/refreshing from the provider when needed
     pub async fn get(&self) -> Result<Credentials> {
         match self {
             CredentialSource::Static(c) => Ok(c.clone()),
             CredentialSource::Imds(p) => p.credentials().await,
+            CredentialSource::Ambient(p) => p.credentials().await,
         }
     }
 
-    /// Stable identity for server-side-copy eligibility. IMDS keys rotate, so
-    /// a key-based identity would spuriously fail; fold IMDS to a constant
+    /// Stable identity for server-side-copy eligibility. Temporary creds
+    /// rotate, so a key-based identity would spuriously fail; fold every
+    /// refreshing source to a constant
     pub fn identity(&self) -> &str {
         match self {
             CredentialSource::Static(c) => &c.access_key,
             CredentialSource::Imds(_) => "imds",
+            CredentialSource::Ambient(p) => p.kind.label(),
         }
     }
 }
@@ -171,7 +183,174 @@ impl ImdsProvider {
     }
 }
 
-/// IMDS credential document shape (`.../iam/security-credentials/<role>`)
+/// Which ambient endpoint mints the credentials. Both flavors are a single
+/// authenticated HTTP call, so they share one provider and differ only in how
+/// the request is built and how the response is parsed.
+#[derive(Debug)]
+pub enum AmbientKind {
+    /// Container credentials endpoint (EKS Pod Identity / ECS). The response is
+    /// the same document shape as IMDS, so `parse_creds` handles it.
+    Container {
+        /// `AWS_CONTAINER_CREDENTIALS_FULL_URI`, or `..._RELATIVE_URI` joined to
+        /// the ECS link-local base
+        url: String,
+        /// `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` — rotates, so it is re-read
+        /// on every refresh
+        token_file: Option<String>,
+        /// `AWS_CONTAINER_AUTHORIZATION_TOKEN`
+        static_token: Option<String>,
+    },
+    /// STS web-identity (IRSA): exchange the projected ServiceAccount JWT for
+    /// temporary creds. The AWS Query protocol answers with XML.
+    WebIdentity {
+        sts_endpoint: String,
+        role_arn: String,
+        session_name: String,
+        /// `AWS_WEB_IDENTITY_TOKEN_FILE` — rotates, so it is re-read on every
+        /// refresh
+        token_file: String,
+    },
+}
+
+impl AmbientKind {
+    /// Rotation-stable name, used both for `CredentialSource::identity` and to
+    /// label client-construction errors
+    fn label(&self) -> &'static str {
+        match self {
+            AmbientKind::Container { .. } => "container-creds",
+            AmbientKind::WebIdentity { .. } => "web-identity",
+        }
+    }
+}
+
+/// Ambient (keyless) per-pod credential provider, caching the last fetch until
+/// it nears expiry — same shape as `ImdsProvider`.
+#[derive(Debug)]
+pub struct AmbientProvider {
+    client: Client,
+    kind: AmbientKind,
+    cached: Mutex<Option<Credentials>>,
+}
+
+impl AmbientProvider {
+    pub fn new(kind: AmbientKind) -> Result<Self> {
+        // container creds live on a link-local address, which must never
+        // traverse a proxy, and should fail fast off-cluster. STS is a public
+        // endpoint: normal timeout, proxy allowed.
+        let builder = match &kind {
+            AmbientKind::Container { .. } => Client::builder()
+                .timeout(Duration::from_secs(5))
+                .connect_timeout(Duration::from_secs(1))
+                .no_proxy(),
+            AmbientKind::WebIdentity { .. } => Client::builder().timeout(Duration::from_secs(10)),
+        };
+        let client = builder
+            .build()
+            .map_err(|e| StorageError::Config(format!("{} client: {e}", kind.label())))?;
+        Ok(Self {
+            client,
+            kind,
+            cached: Mutex::new(None),
+        })
+    }
+
+    /// Single-flight: the lock spans the fetch so concurrent signers don't
+    /// stampede the endpoint. Cache hits clone and return immediately.
+    pub async fn credentials(&self) -> Result<Credentials> {
+        let mut guard = self.cached.lock().await;
+        if let Some(c) = guard.as_ref()
+            && !c.expires_within(REFRESH_MARGIN)
+        {
+            return Ok(c.clone());
+        }
+        let fresh = self.fetch().await?;
+        *guard = Some(fresh.clone());
+        Ok(fresh)
+    }
+
+    async fn fetch(&self) -> Result<Credentials> {
+        let req = match &self.kind {
+            AmbientKind::Container {
+                url,
+                token_file,
+                static_token,
+            } => {
+                let mut req = self.client.get(url);
+                // a rotating token file wins over a static token; both optional
+                match (token_file, static_token) {
+                    (Some(path), _) => req = req.header("Authorization", read_token(path)?),
+                    (None, Some(tok)) => req = req.header("Authorization", tok),
+                    (None, None) => {}
+                }
+                req
+            }
+            AmbientKind::WebIdentity {
+                sts_endpoint,
+                role_arn,
+                session_name,
+                token_file,
+            } => {
+                let token = read_token(token_file)?;
+                self.client.post(sts_endpoint).form(&[
+                    ("Action", "AssumeRoleWithWebIdentity"),
+                    ("Version", "2011-06-15"),
+                    ("RoleArn", role_arn.as_str()),
+                    ("RoleSessionName", session_name.as_str()),
+                    ("WebIdentityToken", token.as_str()),
+                ])
+            }
+        };
+        let resp = req.send().await?;
+        let status = resp.status();
+        let body = resp.text().await?;
+        if !status.is_success() {
+            // Http (not Auth) so a 5xx from the endpoint stays retryable
+            return Err(StorageError::Http {
+                status: status.as_u16(),
+                body,
+            });
+        }
+        match &self.kind {
+            AmbientKind::Container { .. } => parse_creds(&body),
+            AmbientKind::WebIdentity { .. } => parse_sts_creds(&body),
+        }
+    }
+}
+
+/// Projected/rotating token files are re-read on every refresh, never cached
+fn read_token(path: &str) -> Result<String> {
+    std::fs::read_to_string(path)
+        .map(|t| t.trim().to_string())
+        .map_err(|e| StorageError::Auth(format!("read token {path}: {e}")))
+}
+
+/// Temporary creds from an `AssumeRoleWithWebIdentity` XML response.
+/// `first_tag_text` matches on local element name, so nesting is irrelevant.
+fn parse_sts_creds(xml: &str) -> Result<Credentials> {
+    use crate::storage::s3::first_tag_text;
+    let need = |tag: &'static [u8]| {
+        first_tag_text(xml, tag).ok_or_else(|| {
+            StorageError::Auth(format!("sts: missing {}", String::from_utf8_lossy(tag)))
+        })
+    };
+    Ok(Credentials {
+        access_key: need(b"AccessKeyId")?,
+        secret_key: need(b"SecretAccessKey")?,
+        // Some(..) for temporary creds -> x-amz-security-token gets signed
+        session_token: first_tag_text(xml, b"SessionToken"),
+        expires_at: Some(parse_expiry(&need(b"Expiration")?)?),
+    })
+}
+
+/// Expiry as reported by IMDS, container credentials, and STS
+fn parse_expiry(raw: &str) -> Result<SystemTime> {
+    chrono::DateTime::parse_from_rfc3339(raw)
+        .map(SystemTime::from)
+        .map_err(|e| StorageError::Auth(format!("expiration {raw:?}: {e}")))
+}
+
+/// IMDS credential document shape (`.../iam/security-credentials/<role>`),
+/// also returned verbatim by the container credentials endpoint
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
 struct ImdsCreds {
@@ -191,9 +370,7 @@ fn parse_creds(body: &str) -> Result<Credentials> {
     {
         return Err(StorageError::Auth(format!("imds creds code {code}")));
     }
-    let expires_at = chrono::DateTime::parse_from_rfc3339(&raw.expiration)
-        .map(SystemTime::from)
-        .map_err(|e| StorageError::Auth(format!("imds expiration {:?}: {e}", raw.expiration)))?;
+    let expires_at = parse_expiry(&raw.expiration)?;
     Ok(Credentials {
         access_key: raw.access_key_id,
         secret_key: raw.secret_access_key,
@@ -374,5 +551,188 @@ mod tests {
         // is what rejects it
         let body = r#"{"Code":"AssumeRoleUnauthorizedAccess","AccessKeyId":"x","SecretAccessKey":"y","Token":"z","Expiration":"2030-01-01T00:00:00Z"}"#;
         assert!(matches!(parse_creds(body), Err(StorageError::Auth(_))));
+    }
+
+    /// Mock container-credentials endpoint counting fetches (so caching is
+    /// observable) and recording the Authorization header it saw.
+    async fn container_endpoint(
+        expiration: String,
+    ) -> (
+        String,
+        Arc<AtomicU32>,
+        Arc<std::sync::Mutex<Option<String>>>,
+    ) {
+        let fetches = Arc::new(AtomicU32::new(0));
+        // std mutex: the handler is sync, called from inside an async task
+        let seen = Arc::new(std::sync::Mutex::new(None));
+        let (f, s) = (fetches.clone(), seen.clone());
+        let base = serve(move |req: &Req| {
+            f.fetch_add(1, Ordering::SeqCst);
+            *s.lock().unwrap() = req.headers.get("authorization").cloned();
+            Resp::new(200).body(creds_json(&expiration).into_bytes())
+        })
+        .await;
+        (base, fetches, seen)
+    }
+
+    #[tokio::test]
+    async fn container_creds_parse_cache_and_send_static_token() {
+        let exp = (Utc::now() + chrono::Duration::hours(6)).to_rfc3339();
+        let (base, fetches, seen) = container_endpoint(exp).await;
+        let p = AmbientProvider::new(AmbientKind::Container {
+            url: format!("{base}/v1/credentials"),
+            token_file: None,
+            static_token: Some("tok".into()),
+        })
+        .unwrap();
+
+        // Pod Identity / ECS answer with the IMDS document shape
+        let c = p.credentials().await.unwrap();
+        assert_eq!(c.access_key, "ASIAEXAMPLE");
+        assert_eq!(c.session_token.as_deref(), Some("sessiontok"));
+        assert!(c.expires_at.is_some());
+
+        p.credentials().await.unwrap();
+        assert_eq!(fetches.load(Ordering::SeqCst), 1, "second call must cache");
+        assert_eq!(seen.lock().unwrap().as_deref(), Some("tok"));
+
+        let src = CredentialSource::Ambient(Arc::new(p));
+        assert_eq!(src.identity(), "container-creds");
+        assert_eq!(src.get().await.unwrap().access_key, "ASIAEXAMPLE");
+    }
+
+    #[tokio::test]
+    async fn container_creds_token_file_wins_over_static_token() {
+        let exp = (Utc::now() + chrono::Duration::hours(6)).to_rfc3339();
+        let (base, _, seen) = container_endpoint(exp).await;
+        // EKS Pod Identity projects a rotating token file; it must take priority
+        let f = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(f.path(), "  from-file\n").unwrap();
+        let p = AmbientProvider::new(AmbientKind::Container {
+            url: format!("{base}/v1/credentials"),
+            token_file: Some(f.path().to_string_lossy().into()),
+            static_token: Some("static".into()),
+        })
+        .unwrap();
+
+        p.credentials().await.unwrap();
+        // trimmed, so a trailing newline in the projected file isn't sent
+        assert_eq!(seen.lock().unwrap().as_deref(), Some("from-file"));
+    }
+
+    #[tokio::test]
+    async fn container_creds_surface_http_errors() {
+        let base = serve(|_req: &Req| Resp::new(500).body(b"boom".to_vec())).await;
+        let p = AmbientProvider::new(AmbientKind::Container {
+            url: base,
+            token_file: None,
+            static_token: None,
+        })
+        .unwrap();
+        // Http, not Auth, so the outer retry treats a 5xx as transient
+        assert!(matches!(
+            p.credentials().await,
+            Err(StorageError::Http { status: 500, .. })
+        ));
+    }
+
+    fn sts_xml(expiration: &str) -> String {
+        format!(
+            r#"<AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleWithWebIdentityResult><Credentials>
+    <AccessKeyId>ASIAWEBID</AccessKeyId><SecretAccessKey>websecret</SecretAccessKey>
+    <SessionToken>webtok</SessionToken><Expiration>{expiration}</Expiration>
+  </Credentials></AssumeRoleWithWebIdentityResult>
+</AssumeRoleWithWebIdentityResponse>"#
+        )
+    }
+
+    /// Mock STS returning an AssumeRoleWithWebIdentity document, plus a projected
+    /// token file for the provider to read.
+    async fn web_identity(
+        expiration: String,
+    ) -> (AmbientProvider, Arc<AtomicU32>, tempfile::NamedTempFile) {
+        let fetches = Arc::new(AtomicU32::new(0));
+        let f = fetches.clone();
+        let base = serve(move |req: &Req| {
+            // Query protocol: form-encoded POST, XML response
+            let body = String::from_utf8_lossy(&req.body).to_string();
+            if req.method != "POST" || !body.contains("Action=AssumeRoleWithWebIdentity") {
+                return Resp::new(400);
+            }
+            f.fetch_add(1, Ordering::SeqCst);
+            Resp::new(200).body(sts_xml(&expiration).into_bytes())
+        })
+        .await;
+        let token = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(token.path(), "eyJhbGciOiJSUzI1NiJ9.payload.sig\n").unwrap();
+        let p = AmbientProvider::new(AmbientKind::WebIdentity {
+            sts_endpoint: base,
+            role_arn: "arn:aws:iam::1:role/r".into(),
+            session_name: "wal-rus".into(),
+            token_file: token.path().to_string_lossy().into(),
+        })
+        .unwrap();
+        (p, fetches, token)
+    }
+
+    #[tokio::test]
+    async fn web_identity_exchanges_token_caches_and_identity_is_constant() {
+        let exp = (Utc::now() + chrono::Duration::hours(6)).to_rfc3339();
+        let (p, fetches, _token) = web_identity(exp).await;
+
+        let c = p.credentials().await.unwrap();
+        assert_eq!(c.access_key, "ASIAWEBID");
+        assert_eq!(c.secret_key, "websecret");
+        // Some(..) is what makes the signer emit x-amz-security-token
+        assert_eq!(c.session_token.as_deref(), Some("webtok"));
+        assert!(c.expires_at.is_some());
+
+        p.credentials().await.unwrap();
+        assert_eq!(fetches.load(Ordering::SeqCst), 1, "second call must cache");
+
+        let src = CredentialSource::Ambient(Arc::new(p));
+        assert_eq!(src.identity(), "web-identity");
+    }
+
+    #[tokio::test]
+    async fn web_identity_refetches_when_expiring_within_margin() {
+        // expiry inside REFRESH_MARGIN -> every call re-reads the rotating token
+        let exp = (Utc::now() + chrono::Duration::seconds(60)).to_rfc3339();
+        let (p, fetches, _token) = web_identity(exp).await;
+        p.credentials().await.unwrap();
+        p.credentials().await.unwrap();
+        assert_eq!(fetches.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn web_identity_missing_token_file_is_an_auth_error() {
+        let p = AmbientProvider::new(AmbientKind::WebIdentity {
+            sts_endpoint: "http://127.0.0.1:1".into(),
+            role_arn: "arn:aws:iam::1:role/r".into(),
+            session_name: "wal-rus".into(),
+            token_file: "/nonexistent/projected/token".into(),
+        })
+        .unwrap();
+        assert!(matches!(p.credentials().await, Err(StorageError::Auth(_))));
+    }
+
+    #[test]
+    fn parse_sts_creds_requires_the_key_fields() {
+        let missing = "<AssumeRoleWithWebIdentityResponse><Credentials>\
+            <SecretAccessKey>s</SecretAccessKey></Credentials></AssumeRoleWithWebIdentityResponse>";
+        assert!(matches!(
+            parse_sts_creds(missing),
+            Err(StorageError::Auth(_))
+        ));
+        // SessionToken is the only optional field
+        let no_token = format!(
+            "<Credentials><AccessKeyId>a</AccessKeyId><SecretAccessKey>s</SecretAccessKey>\
+             <Expiration>{}</Expiration></Credentials>",
+            (Utc::now() + chrono::Duration::hours(1)).to_rfc3339()
+        );
+        let c = parse_sts_creds(&no_token).unwrap();
+        assert_eq!(c.access_key, "a");
+        assert!(c.session_token.is_none());
     }
 }

--- a/src/storage/gcs.rs
+++ b/src/storage/gcs.rs
@@ -1,9 +1,11 @@
 //! GCS backend
 //!
-//! Auth: service-account JSON file pointed to by GOOGLE_APPLICATION_CREDENTIALS
-//! Streaming uploads via chunked transfer encoding (uploadType=media)
+//! Auth: the service-account JSON pointed to by GOOGLE_APPLICATION_CREDENTIALS
+//! when set, otherwise the GKE/GCE metadata server (Workload Identity) — no key
+//! material. Streaming uploads via chunked transfer encoding (uploadType=media)
 //!
-//! Env: GOOGLE_APPLICATION_CREDENTIALS, WALG_GS_PREFIX (parsed by config layer)
+//! Env: GOOGLE_APPLICATION_CREDENTIALS, GCE_METADATA_HOST, WALG_GS_PREFIX
+//! (parsed by config layer)
 
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -30,6 +32,9 @@ use super::{
 const TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
 const STORAGE_HOST: &str = "https://storage.googleapis.com";
 const SCOPE: &str = "https://www.googleapis.com/auth/devstorage.read_write";
+/// GKE/GCE metadata server; override with `GCE_METADATA_HOST`
+const METADATA_HOST: &str = "metadata.google.internal";
+const METADATA_TOKEN_PATH: &str = "/computeMetadata/v1/instance/service-accounts/default/token";
 
 #[derive(Debug, Deserialize)]
 struct ServiceAccount {
@@ -44,6 +49,13 @@ struct CachedToken {
     expires_at: SystemTime,
 }
 
+/// OAuth2 token response, shared by the JWT-bearer mint and the metadata server
+#[derive(Deserialize)]
+struct TokenResp {
+    access_token: String,
+    expires_in: u64,
+}
+
 #[derive(Debug, Clone)]
 pub struct GcsConfig {
     pub bucket: String,
@@ -52,13 +64,18 @@ pub struct GcsConfig {
     /// Emulator endpoint (fake-gcs-server); resolved from `WALG_GS_ENDPOINT` /
     /// `STORAGE_EMULATOR_HOST` in the config layer. `Some` disables auth
     pub endpoint: Option<String>,
+    /// Metadata-server host override (`GCE_METADATA_HOST`), the standard Google
+    /// variable; defaults to `metadata.google.internal`. Accepts a bare host or
+    /// a full http(s) base, which is also the seam tests point at a mock
+    pub metadata_endpoint: Option<String>,
 }
 
 pub struct GcsStorage {
     cfg: GcsConfig,
     client: Client,
     host: String,
-    /// None in emulator mode (fake-gcs-server): no service account, no oauth2
+    /// None in emulator mode (fake-gcs-server: no auth at all) and under
+    /// Workload Identity, where the metadata server mints the token instead
     sa: Option<ServiceAccount>,
     token: Arc<Mutex<Option<CachedToken>>>,
 }
@@ -74,11 +91,7 @@ impl GcsStorage {
         // plain HTTP and ignores auth. Skip credentials + the oauth2 token mint
         // entirely.
         if let Some(ep) = cfg.endpoint.as_deref().filter(|s| !s.is_empty()) {
-            let host = if ep.starts_with("http://") || ep.starts_with("https://") {
-                ep.trim_end_matches('/').to_string()
-            } else {
-                format!("http://{}", ep.trim_end_matches('/'))
-            };
+            let host = http_base(ep);
             return Ok(Self {
                 cfg,
                 client,
@@ -88,23 +101,36 @@ impl GcsStorage {
             });
         }
 
-        let path = cfg.credentials_path.clone().ok_or_else(|| {
-            StorageError::Config(
-                "GOOGLE_APPLICATION_CREDENTIALS not set; metadata-server auth not yet supported"
-                    .into(),
-            )
-        })?;
-        let raw = std::fs::read_to_string(&path)
-            .map_err(|e| StorageError::Config(format!("read credentials {}: {}", path, e)))?;
-        let sa: ServiceAccount = serde_json::from_str(&raw)
-            .map_err(|e| StorageError::Config(format!("parse credentials: {e}")))?;
+        // An SA-JSON path selects JWT-bearer auth; without one, fall back to the
+        // metadata server (Workload Identity), mirroring the AWS "no static keys
+        // -> IMDS" default. An empty value counts as unset, so it falls back
+        // rather than failing on a read of "".
+        let sa = match cfg.credentials_path.as_deref().filter(|s| !s.is_empty()) {
+            Some(path) => {
+                let raw = std::fs::read_to_string(path)
+                    .map_err(|e| StorageError::Config(format!("read credentials {path}: {e}")))?;
+                // note: the private key is parsed lazily, at first mint
+                Some(
+                    serde_json::from_str(&raw)
+                        .map_err(|e| StorageError::Config(format!("parse credentials: {e}")))?,
+                )
+            }
+            None => None,
+        };
         Ok(Self {
             cfg,
             client,
             host: STORAGE_HOST.to_string(),
-            sa: Some(sa),
+            sa,
             token: Arc::new(Mutex::new(None)),
         })
+    }
+
+    /// Emulator mode. `new` only rewrites `host` for a fake-gcs-server endpoint,
+    /// so a non-default host is exactly the emulator signal — which frees
+    /// `sa: None` to mean metadata-server auth.
+    fn is_emulator(&self) -> bool {
+        self.host != STORAGE_HOST
     }
 
     fn full_key(&self, key: &str) -> String {
@@ -113,9 +139,9 @@ impl GcsStorage {
 
     async fn access_token(&self) -> Result<String> {
         // Emulator mode: fake-gcs-server ignores the bearer token
-        let Some(sa) = self.sa.as_ref() else {
+        if self.is_emulator() {
             return Ok("emulator".into());
-        };
+        }
         let mut guard = self.token.lock().await;
         let now = SystemTime::now();
         if let Some(c) = guard.as_ref()
@@ -124,6 +150,49 @@ impl GcsStorage {
             return Ok(c.token.clone());
         }
 
+        // Both sources answer with the same OAuth2 token document, so only the
+        // request differs
+        let req = match self.sa.as_ref() {
+            Some(sa) => self.jwt_bearer_request(sa, now)?,
+            None => self.metadata_request(),
+        };
+        let resp = req.send().await?;
+
+        if !resp.status().is_success() {
+            let st = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(StorageError::Auth(format!("token endpoint {st}: {body}")));
+        }
+
+        let tr: TokenResp = resp.json().await?;
+        let exp = now + Duration::from_secs(tr.expires_in);
+        *guard = Some(CachedToken {
+            token: tr.access_token.clone(),
+            expires_at: exp,
+        });
+        Ok(tr.access_token)
+    }
+
+    /// ADC via the GKE/GCE metadata server (Workload Identity): the pod's bound
+    /// service account is resolved by the host, so there is no key to sign with
+    fn metadata_request(&self) -> reqwest::RequestBuilder {
+        let base = http_base(
+            self.cfg
+                .metadata_endpoint
+                .as_deref()
+                .unwrap_or(METADATA_HOST),
+        );
+        self.client
+            .get(format!("{base}{METADATA_TOKEN_PATH}"))
+            .header("Metadata-Flavor", "Google")
+    }
+
+    /// Self-signed JWT-bearer assertion from a mounted service-account key
+    fn jwt_bearer_request(
+        &self,
+        sa: &ServiceAccount,
+        now: SystemTime,
+    ) -> Result<reqwest::RequestBuilder> {
         let now_secs = now
             .duration_since(UNIX_EPOCH)
             .map_err(|e| StorageError::Auth(e.to_string()))?
@@ -151,34 +220,10 @@ impl GcsStorage {
         let jwt = format!("{signing_input}.{s_b64}");
 
         let token_url = sa.token_uri.as_deref().unwrap_or(TOKEN_URL);
-        let resp = self
-            .client
-            .post(token_url)
-            .form(&[
-                ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
-                ("assertion", jwt.as_str()),
-            ])
-            .send()
-            .await?;
-
-        if !resp.status().is_success() {
-            let st = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            return Err(StorageError::Auth(format!("token endpoint {st}: {body}")));
-        }
-
-        #[derive(Deserialize)]
-        struct TokenResp {
-            access_token: String,
-            expires_in: u64,
-        }
-        let tr: TokenResp = resp.json().await?;
-        let exp = now + Duration::from_secs(tr.expires_in);
-        *guard = Some(CachedToken {
-            token: tr.access_token.clone(),
-            expires_at: exp,
-        });
-        Ok(tr.access_token)
+        Ok(self.client.post(token_url).form(&[
+            ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
+            ("assertion", jwt.as_str()),
+        ]))
     }
 
     fn object_url(&self, key: &str) -> String {
@@ -189,12 +234,26 @@ impl GcsStorage {
 
     /// Server-side copy identity: rewriteTo authorizes both sides with one
     /// token, so same service account (or same emulator host) is the safe
-    /// equivalence
+    /// equivalence. Workload Identity folds to a constant because the bound
+    /// identity is ambient and its token rotates — the same tradeoff `imds`
+    /// makes for S3, except a cross-identity rewrite surfaces as a 403 rather
+    /// than falling back to stream-through.
     fn backend_id(&self) -> String {
         match self.sa.as_ref() {
             Some(sa) => format!("gs:{}", sa.client_email),
-            None => format!("gs:emulator:{}", self.host),
+            None if self.is_emulator() => format!("gs:emulator:{}", self.host),
+            None => "gs:metadata".to_string(),
         }
+    }
+}
+
+/// Normalize a bare host or a full http(s) base into a base URL
+fn http_base(s: &str) -> String {
+    let s = s.trim_end_matches('/');
+    if s.starts_with("http://") || s.starts_with("https://") {
+        s.to_string()
+    } else {
+        format!("http://{s}")
     }
 }
 
@@ -581,9 +640,11 @@ mod tests {
             prefix: "p".into(),
             credentials_path: None,
             endpoint: Some("http://127.0.0.1:4443".into()),
+            metadata_endpoint: None,
         })
         .expect("emulator mode needs no credentials");
         assert!(s.sa.is_none());
+        assert!(s.is_emulator());
         assert_eq!(s.host, "http://127.0.0.1:4443");
         assert!(
             s.object_url("wal_005/x")
@@ -601,6 +662,7 @@ mod tests {
                 prefix: "p".into(),
                 credentials_path: None,
                 endpoint: None,
+                metadata_endpoint: None,
             },
             client: Client::builder().build().unwrap(),
             host,
@@ -766,9 +828,12 @@ mod tests {
                 prefix: "p".into(),
                 credentials_path: None,
                 endpoint: None,
+                metadata_endpoint: None,
             },
             client: Client::builder().build().unwrap(),
-            host: "http://127.0.0.1:1".into(), // unused: access_token only hits token_uri
+            // the SA branch only hits token_uri, but the host must stay the real
+            // one or is_emulator() would short-circuit to the emulator token
+            host: STORAGE_HOST.to_string(),
             sa: Some(ServiceAccount {
                 client_email: "svc@test.iam.gserviceaccount.com".into(),
                 private_key: pem,
@@ -785,5 +850,63 @@ mod tests {
             1,
             "second token request must hit the cache"
         );
+    }
+
+    /// Workload Identity: no SA-JSON, so the token comes from the metadata
+    /// server. No key material and no signing involved.
+    #[tokio::test]
+    async fn metadata_token_reads_from_metadata_server_and_caches() {
+        use crate::storage::test_http::{Req, Resp, serve};
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        let hits = Arc::new(AtomicU32::new(0));
+        let h = hits.clone();
+        let base = serve(move |req: &Req| {
+            // the metadata server requires this header, and test_http lowercases
+            // header names but not values
+            if req.headers.get("metadata-flavor").map(String::as_str) != Some("Google") {
+                return Resp::new(403);
+            }
+            if req.path != METADATA_TOKEN_PATH {
+                return Resp::new(404);
+            }
+            h.fetch_add(1, Ordering::SeqCst);
+            Resp::new(200).body(b"{\"access_token\":\"tok\",\"expires_in\":3600}".to_vec())
+        })
+        .await;
+
+        let s = GcsStorage {
+            cfg: GcsConfig {
+                bucket: "b".into(),
+                prefix: "p".into(),
+                credentials_path: None,
+                endpoint: None,
+                metadata_endpoint: Some(base),
+            },
+            client: Client::builder().build().unwrap(),
+            host: STORAGE_HOST.to_string(),
+            sa: None,
+            token: Arc::new(Mutex::new(None)),
+        };
+
+        assert_eq!(s.access_token().await.unwrap(), "tok");
+        assert_eq!(s.access_token().await.unwrap(), "tok");
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            1,
+            "second token request must hit the cache"
+        );
+        // rotation-stable, unlike the SA-JSON client_email identity
+        assert_eq!(s.backend_id(), "gs:metadata");
+    }
+
+    #[test]
+    fn http_base_accepts_bare_host_and_full_url() {
+        assert_eq!(
+            http_base("metadata.google.internal"),
+            "http://metadata.google.internal"
+        );
+        assert_eq!(http_base("http://127.0.0.1:8080/"), "http://127.0.0.1:8080");
+        assert_eq!(http_base("https://example.test"), "https://example.test");
     }
 }

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -5,7 +5,9 @@
 //! Env vars: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN,
 //! AWS_REGION (default us-east-1), endpoint from AWS_ENDPOINT_URL / AWS_ENDPOINT
 //! / WALG_S3_ENDPOINT, path-style from AWS_S3_FORCE_PATH_STYLE. Without static
-//! keys, credentials come from the EC2 metadata service (see [`super::creds`])
+//! keys, credentials come from web-identity (IRSA), the container credentials
+//! endpoint (EKS Pod Identity / ECS), or the EC2 metadata service, in that
+//! order (see [`super::creds`])
 
 use std::io::Cursor;
 use std::sync::Arc;
@@ -26,7 +28,7 @@ use tokio::task::JoinSet;
 use tokio_util::io::StreamReader;
 use url::Url;
 
-pub use super::creds::{CredentialSource, Credentials, ImdsProvider};
+pub use super::creds::{AmbientKind, AmbientProvider, CredentialSource, Credentials, ImdsProvider};
 use super::{
     AsyncReader, CopySource, ObjectMeta, ObjectStream, PutIfAbsentOutcome, Result, Storage,
     StorageError,
@@ -780,8 +782,9 @@ fn decode_text(t: &quick_xml::events::BytesText) -> Result<String> {
 }
 
 /// Text of the first element whose local name matches `tag`. Used for the
-/// single-valued CreateMultipartUpload `UploadId`.
-fn first_tag_text(xml: &str, tag: &[u8]) -> Option<String> {
+/// single-valued CreateMultipartUpload `UploadId`, and by `creds.rs` for the
+/// STS AssumeRoleWithWebIdentity response.
+pub(crate) fn first_tag_text(xml: &str, tag: &[u8]) -> Option<String> {
     let mut reader = Reader::from_str(xml);
     let mut capture = false;
     loop {


### PR DESCRIPTION
**Draft — not ready for review.**

Lets a receiver authenticate to object storage with ambient per-pod identity instead of static keys, so each one can run under its own ServiceAccount bound to a scoped cloud role.

- **S3** — web-identity (IRSA) via STS `AssumeRoleWithWebIdentity`, and the container credentials endpoint (EKS Pod Identity / ECS).
- **GCS** — the GKE/GCE metadata server (Workload Identity), replacing the `metadata-server auth not yet supported` hard error.

No new dependencies.

## Credential chain

`src` (backup-copy inherit) → static keys → web-identity → container credentials → EC2 IMDS → error if `AWS_EC2_METADATA_DISABLED`.

This mirrors the AWS SDKs, which is where wal-g gets the same behavior — it writes essentially no credential code of its own (`session.NewSessionWithOptions` plus the SDK default chain; `gcs.NewClient(ctx)` for pure ADC on the GCS side). Static keys and GCS SA-JSON still win when present, so **existing deployments are unaffected** and this can ship independently of the operator work. Incomplete static keys remain a hard error.

## Env-var contract

| Source | Vars |
|---|---|
| S3 web-identity | `AWS_WEB_IDENTITY_TOKEN_FILE` + `AWS_ROLE_ARN`; optional `AWS_ROLE_SESSION_NAME`, `AWS_ENDPOINT_URL_STS` |
| S3 container creds | `AWS_CONTAINER_CREDENTIALS_FULL_URI` or `..._RELATIVE_URI`; optional `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` / `AWS_CONTAINER_AUTHORIZATION_TOKEN` |
| GCS Workload Identity | none — absence of `GOOGLE_APPLICATION_CREDENTIALS` selects it; `GCE_METADATA_HOST` overrides the host |

On EKS/GKE the platform injects these itself once the pod runs under a bound ServiceAccount.

## Notes for the reviewer

- **One provider, not two.** Both new S3 sources are a single authenticated HTTP call plus the cache/refresh `ImdsProvider` already had, so they share one `AmbientProvider` behind an `AmbientKind` enum — one `credentials()` body, one client builder, one send/status/body block, and one new `CredentialSource` arm instead of two. Container creds return the IMDS document shape, so `parse_creds` is reused; STS returns Query-protocol XML, parsed with `s3::first_tag_text` (now `pub(crate)`).
- **No GCS auth enum.** `new()` only rewrites `host` away from `STORAGE_HOST` for the emulator, so `is_emulator()` recovers that state and `sa: None` can mean metadata auth. Both token paths end in the same status check → `TokenResp` → cache write, so `access_token` keeps that once and only the request differs.
- **No signing changes.** `x-amz-security-token` was already threaded and creds are fetched per request. `identity()` folds each refreshing source to a constant, so rotation can't spuriously fail server-side-copy eligibility.
- Rotating token files (projected SA JWT, Pod Identity auth token) are re-read on every refresh, never cached. A token file takes precedence over a static token, matching the SDK.
- Non-2xx from STS or the container endpoint maps to `StorageError::Http`, so a 5xx stays retryable via `is_transient`.
- `GOOGLE_APPLICATION_CREDENTIALS=""` now falls back to metadata instead of failing on a read of `""`.

## Breaking change

`GcsConfig` gains a public `metadata_endpoint` field, which breaks external struct-literal construction — hence **0.3.0** rather than a patch. It carries `GCE_METADATA_HOST` and is the seam the metadata tests point at a mock.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets --locked -- -D warnings`, and `cargo test --locked` are all clean — **544 tests**, 11 of them new (container creds incl. token-file precedence and HTTP errors, web-identity incl. caching, refresh-within-margin and missing-token-file, the STS XML parser, the GCS metadata token, and chain-order/precedence selection in config). The golden SigV4 signature tests are untouched.

No end-to-end cloud validation is possible from a devcontainer, so the mock-HTTP tests are the contract; real-cloud validation happens downstream once a per-tenant ServiceAccount is bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
